### PR TITLE
Create .codacy.yaml to not analyse JSON files

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,0 +1,6 @@
+---
+exclude_paths:
+  - "CPE/data/**"
+  - "CVE/data/**"  
+  - "CWE/data/**"  
+  - "VIA/data/**"


### PR DESCRIPTION
Hey there @pedrocodacy from the Codacy dev team here 👋 

I've noticed through internal monitoring of the product that you have this repo integrated in our product and are getting 45-60 minutes analysis times. 
Looking through your configuration, I can see that you have already disabled all code patterns that analyze JSON files, which seems to indicated that you are not interested in analyzing these.
One detail that is relevant for your usage of the product is that Codacy will still run a bunch of background code metrics calculations on JSON to calculate number of lines of code in this case. Given the large amount of JSON files in this repo, this ends up severely hurting your analysis times.

This PR introduces a [Codacy configuration file](https://docs.codacy.com/repositories-configure/codacy-configuration-file/) at the root of your repo, ignoring these files.
From tests I did with a forked version of this repo, I got analysis times of commits to drop to under 15 minutes.

Have a nice day 👋 🌻 